### PR TITLE
[appinio_swiper] Add direction to emptyFunctionIndex

### DIFF
--- a/packages/appinio_swiper/lib/appinio_swiper.dart
+++ b/packages/appinio_swiper/lib/appinio_swiper.dart
@@ -547,7 +547,7 @@ class _AppinioSwiperState extends State<AppinioSwiper>
 
 //for null safety
 void emptyFunction() {}
-void emptyFunctionIndex(int index) {}
+void emptyFunctionIndex(int index, AppinioSwiperDirection direction) {}
 void emptyFunctionBool(bool unswiped) {}
 
 //to call the swipe or unswipe function from outside of the appinio swiper


### PR DESCRIPTION
# Issue

The `emptyFunctionIndex` that is used when no `onSwipe` callback is provided is missing the direction parameter.
This will throw a `NoSuchMethodError`:

```console
The following NoSuchMethodError was thrown while notifying status listeners for AnimationController:
Closure call with mismatched arguments: function 'emptyFunctionIndex'
Receiver: Closure: (int, AppinioSwiperDirection) => void from Function 'emptyFunctionIndex': static.
Tried calling: emptyFunctionIndex(3, Instance of 'AppinioSwiperDirection')
```

# Solution

This PR will add the missing parameter.