### PR TITLE
[Feature] add parameter isAlwaysLandscapeOnFullscreen on CustomVideoPlayerController

### DIFF
--- a/packages/appinio_video_player/lib/src/custom_video_player_controller.dart
+++ b/packages/appinio_video_player/lib/src/custom_video_player_controller.dart
@@ -1,10 +1,11 @@
 import 'dart:async';
+
 import 'package:appinio_video_player/src/fullscreen_video_player.dart';
-import 'package:flutter/foundation.dart';
-import 'package:flutter/services.dart';
-import 'package:flutter/material.dart';
-import 'package:video_player/video_player.dart';
 import 'package:appinio_video_player/src/models/custom_video_player_settings.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:video_player/video_player.dart';
 
 /// The extension on the class is able to call private methods
 /// only the package can use these methods and not the public beacuse of the hide keyword in the package exports
@@ -23,12 +24,14 @@ class CustomVideoPlayerController {
   VideoPlayerController videoPlayerController;
   final CustomVideoPlayerSettings customVideoPlayerSettings;
   final Map<String, VideoPlayerController>? additionalVideoSources;
+  final bool isAlwaysLandscapeOnFullscreen;
 
   CustomVideoPlayerController({
     required this.context,
     required this.videoPlayerController,
     this.customVideoPlayerSettings = const CustomVideoPlayerSettings(),
     this.additionalVideoSources,
+    this.isAlwaysLandscapeOnFullscreen = false,
   }) {
     videoPlayerController.addListener(_videoListeners);
   }
@@ -100,7 +103,9 @@ class CustomVideoPlayerController {
     final bool isPortraitVideo = videoWidth < videoHeight;
 
     /// if video has more width than height set landscape orientation
-    if (isLandscapeVideo) {
+    /// or is isAlwaysLandscapeOnFullscreen set with true then fullscreen mode will
+    /// always on landscape mode
+    if (isLandscapeVideo || isAlwaysLandscapeOnFullscreen) {
       SystemChrome.setPreferredOrientations([
         DeviceOrientation.landscapeLeft,
         DeviceOrientation.landscapeRight,


### PR DESCRIPTION
Currently, the library will always show the fullscreen mode on portrait mode when the video resolution is Square, so I put optional parameter on CustomVideoPlayerController who make the video player will always on Landscape fullscreen mode if the value set **true**

