### PR TITLE
[Feature] add parameter isAlwaysLandscapeOnFullscreen on CustomVideoPlayerController and isMutedButton Show

### DIFF
--- a/packages/appinio_video_player/lib/src/controls/control_bar.dart
+++ b/packages/appinio_video_player/lib/src/controls/control_bar.dart
@@ -1,14 +1,16 @@
-import 'package:appinio_video_player/src/custom_video_player_controller.dart';
-import 'package:flutter/material.dart';
+import 'package:appinio_video_player/src/controls/custom_muted_button.dart';
 import 'package:appinio_video_player/src/controls/fullscreen_button.dart';
 import 'package:appinio_video_player/src/controls/play_button.dart';
 import 'package:appinio_video_player/src/controls/progress_bar.dart';
+import 'package:appinio_video_player/src/custom_video_player_controller.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 
 class CustomVideoPlayerControlBar extends StatelessWidget {
   final CustomVideoPlayerController customVideoPlayerController;
   final Function updateVideoState;
   final Function fadeOutOnPlay;
+
   const CustomVideoPlayerControlBar({
     Key? key,
     required this.customVideoPlayerController,
@@ -77,6 +79,11 @@ class CustomVideoPlayerControlBar extends StatelessWidget {
                   );
                 }),
               ),
+            ),
+          if (customVideoPlayerController
+              .customVideoPlayerSettings.showMuteButton)
+            CustomMutedButton(
+              customVideoPlayerController: customVideoPlayerController,
             ),
           if (customVideoPlayerController
               .customVideoPlayerSettings.showFullscreenButton)

--- a/packages/appinio_video_player/lib/src/controls/control_bar.dart
+++ b/packages/appinio_video_player/lib/src/controls/control_bar.dart
@@ -81,7 +81,7 @@ class CustomVideoPlayerControlBar extends StatelessWidget {
               ),
             ),
           if (customVideoPlayerController
-              .customVideoPlayerSettings.showMuteButton)
+              .customVideoPlayerSettings.showMutedButton)
             CustomMutedButton(
               customVideoPlayerController: customVideoPlayerController,
             ),

--- a/packages/appinio_video_player/lib/src/controls/custom_muted_button.dart
+++ b/packages/appinio_video_player/lib/src/controls/custom_muted_button.dart
@@ -1,0 +1,47 @@
+import 'package:appinio_video_player/src/custom_video_player_controller.dart';
+import 'package:flutter/material.dart';
+
+class CustomMutedButton extends StatelessWidget {
+  final CustomVideoPlayerController customVideoPlayerController;
+
+  CustomMutedButton({
+    Key? key,
+    required this.customVideoPlayerController,
+  }) : super(key: key);
+
+  bool isMuted = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(0, 5, 5, 5),
+      child: StatefulBuilder(
+        builder: (context, localState) {
+          return GestureDetector(
+            onTap: () {
+              localState(() {
+                isMuted = !isMuted;
+                if (isMuted) {
+                  customVideoPlayerController.videoPlayerController
+                      .setVolume(0.0);
+                } else {
+                  customVideoPlayerController.videoPlayerController
+                      .setVolume(1.0);
+                }
+              });
+            },
+            child: isMuted
+                ? const Icon(
+                    Icons.volume_off,
+                    color: Colors.white,
+                  )
+                : const Icon(
+                    Icons.volume_up,
+                    color: Colors.white,
+                  ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/packages/appinio_video_player/lib/src/controls/custom_muted_button.dart
+++ b/packages/appinio_video_player/lib/src/controls/custom_muted_button.dart
@@ -13,34 +13,49 @@ class CustomMutedButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(0, 5, 5, 5),
-      child: StatefulBuilder(
-        builder: (context, localState) {
-          return GestureDetector(
-            onTap: () {
-              localState(() {
-                isMuted = !isMuted;
-                if (isMuted) {
-                  customVideoPlayerController.videoPlayerController
-                      .setVolume(0.0);
-                } else {
-                  customVideoPlayerController.videoPlayerController
-                      .setVolume(1.0);
-                }
-              });
-            },
-            child: isMuted
-                ? const Icon(
-                    Icons.volume_off,
-                    color: Colors.white,
-                  )
-                : const Icon(
-                    Icons.volume_up,
-                    color: Colors.white,
-                  ),
-          );
+    return StatefulBuilder(builder: (context, localState) {
+      return GestureDetector(
+        behavior: HitTestBehavior.translucent,
+        onTap: () async {
+          localState(() {
+            customVideoPlayerController.setVolumeMutedUnMuted();
+          });
         },
+        child: customVideoPlayerController.isMuted
+            ? customVideoPlayerController
+                .customVideoPlayerSettings.customMutedButton
+            : customVideoPlayerController
+                .customVideoPlayerSettings.customUnMutedButton,
+      );
+    });
+  }
+}
+
+class CustomVideoPlayerMutedButton extends StatelessWidget {
+  const CustomVideoPlayerMutedButton({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const Padding(
+      padding: EdgeInsets.fromLTRB(0, 5, 5, 5),
+      child: Icon(
+        Icons.volume_off,
+        color: Colors.white,
+      ),
+    );
+  }
+}
+
+class CustomVideoPlayerUnMutedButton extends StatelessWidget {
+  const CustomVideoPlayerUnMutedButton({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const Padding(
+      padding: EdgeInsets.fromLTRB(0, 5, 5, 5),
+      child: Icon(
+        Icons.volume_up,
+        color: Colors.white,
       ),
     );
   }

--- a/packages/appinio_video_player/lib/src/custom_video_player_controller.dart
+++ b/packages/appinio_video_player/lib/src/custom_video_player_controller.dart
@@ -1,10 +1,11 @@
 import 'dart:async';
+
 import 'package:appinio_video_player/src/fullscreen_video_player.dart';
-import 'package:flutter/foundation.dart';
-import 'package:flutter/services.dart';
-import 'package:flutter/material.dart';
-import 'package:video_player/video_player.dart';
 import 'package:appinio_video_player/src/models/custom_video_player_settings.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:video_player/video_player.dart';
 
 /// The extension on the class is able to call private methods
 /// only the package can use these methods and not the public beacuse of the hide keyword in the package exports
@@ -23,12 +24,14 @@ class CustomVideoPlayerController {
   VideoPlayerController videoPlayerController;
   final CustomVideoPlayerSettings customVideoPlayerSettings;
   final Map<String, VideoPlayerController>? additionalVideoSources;
+  final bool isAlwaysLandscapeOnFullscreen;
 
   CustomVideoPlayerController({
     required this.context,
     required this.videoPlayerController,
     this.customVideoPlayerSettings = const CustomVideoPlayerSettings(),
     this.additionalVideoSources,
+    this.isAlwaysLandscapeOnFullscreen = false,
   }) {
     videoPlayerController.addListener(_videoListeners);
   }
@@ -100,7 +103,9 @@ class CustomVideoPlayerController {
     final bool isPortraitVideo = videoWidth < videoHeight;
 
     /// if video has more width than height set landscape orientation
-    if (isLandscapeVideo) {
+    /// or is isAlwaysLandscapeOnFullscreen set with true then fullscreen mode will
+    /// always on landscape mode
+    if (isLandscapeVideo || isAlwaysLandscapeOnFullscreen) {
       SystemChrome.setPreferredOrientations([
         DeviceOrientation.landscapeLeft,
         DeviceOrientation.landscapeRight,

--- a/packages/appinio_video_player/lib/src/custom_video_player_controller.dart
+++ b/packages/appinio_video_player/lib/src/custom_video_player_controller.dart
@@ -11,10 +11,17 @@ import 'package:video_player/video_player.dart';
 /// only the package can use these methods and not the public beacuse of the hide keyword in the package exports
 extension ProtectedCustomVideoPlayerController on CustomVideoPlayerController {
   Future<void> Function(String) get switchVideoSource => _switchVideoSource;
+
   ValueNotifier<Duration> get videoProgressNotifier => _videoProgressNotifier;
+
   ValueNotifier<double> get playbackSpeedNotifier => _playbackSpeedNotifier;
+
   ValueNotifier<bool> get isPlayingNotifier => _isPlayingNotifier;
+
   bool get isFullscreen => _isFullscreen;
+
+  bool get isMuted => _isMuted;
+
   set updateViewAfterFullscreen(Function updateViewAfterFullscreen) =>
       _updateViewAfterFullscreen = updateViewAfterFullscreen;
 }
@@ -59,6 +66,7 @@ class CustomVideoPlayerController {
   Function? _updateViewAfterFullscreen;
 
   bool _isFullscreen = false;
+  bool _isMuted = false;
   Timer? _timer;
   final ValueNotifier<Duration> _videoProgressNotifier =
       ValueNotifier(Duration.zero);
@@ -225,6 +233,16 @@ class CustomVideoPlayerController {
 
   void _playbackSpeedListener() {
     _playbackSpeedNotifier.value = videoPlayerController.value.playbackSpeed;
+  }
+
+  void setVolumeMutedUnMuted() {
+    if (videoPlayerController.value.volume == 0) {
+      videoPlayerController.setVolume(1.0);
+      _isMuted = false;
+    } else {
+      videoPlayerController.setVolume(0.0);
+      _isMuted = true;
+    }
   }
 
   /// call dispose on the dispose method in your parent widget to be sure that every values is disposed

--- a/packages/appinio_video_player/lib/src/models/custom_video_player_settings.dart
+++ b/packages/appinio_video_player/lib/src/models/custom_video_player_settings.dart
@@ -1,5 +1,6 @@
 import 'dart:ui';
 
+import 'package:appinio_video_player/src/controls/custom_muted_button.dart';
 import 'package:appinio_video_player/src/controls/fullscreen_button.dart';
 import 'package:appinio_video_player/src/controls/play_button.dart';
 import 'package:appinio_video_player/src/controls/video_settings_button.dart';
@@ -112,7 +113,13 @@ class CustomVideoPlayerSettings {
   final CustomVideoPlayerPopupSettings customVideoPlayerPopupSettings;
 
   /// UI settings for the video to show muted volume button.
-  final bool showMuteButton;
+  final bool showMutedButton;
+
+  /// Define the muted button appearance.
+  final Widget customMutedButton;
+
+  /// Define the un-muted button appearance.
+  final Widget customUnMutedButton;
 
   const CustomVideoPlayerSettings({
     this.customAspectRatio,
@@ -167,6 +174,8 @@ class CustomVideoPlayerSettings {
     ),
     this.customVideoPlayerPopupSettings =
         const CustomVideoPlayerPopupSettings(),
-    this.showMuteButton = false,
+    this.showMutedButton = false,
+    this.customMutedButton = const CustomVideoPlayerMutedButton(),
+    this.customUnMutedButton = const CustomVideoPlayerUnMutedButton(),
   });
 }

--- a/packages/appinio_video_player/lib/src/models/custom_video_player_settings.dart
+++ b/packages/appinio_video_player/lib/src/models/custom_video_player_settings.dart
@@ -1,4 +1,5 @@
 import 'dart:ui';
+
 import 'package:appinio_video_player/src/controls/fullscreen_button.dart';
 import 'package:appinio_video_player/src/controls/play_button.dart';
 import 'package:appinio_video_player/src/controls/video_settings_button.dart';
@@ -110,6 +111,9 @@ class CustomVideoPlayerSettings {
   /// UI settings for the video settings popup.
   final CustomVideoPlayerPopupSettings customVideoPlayerPopupSettings;
 
+  /// UI settings for the video to show muted volume button.
+  final bool showMuteButton;
+
   const CustomVideoPlayerSettings({
     this.customAspectRatio,
     this.placeholderWidget,
@@ -163,5 +167,6 @@ class CustomVideoPlayerSettings {
     ),
     this.customVideoPlayerPopupSettings =
         const CustomVideoPlayerPopupSettings(),
+    this.showMuteButton = false,
   });
 }


### PR DESCRIPTION
Currently, the library will always show the fullscreen mode in portrait mode when the video resolution is Square, so I put an optional parameter on CustomVideoPlayerController which make the video player will always on Landscape fullscreen mode if the value is set to true

and I put showMutedButton to show muted button, and the user can customize the button's appearance, so with this changes, user can muted and unmuted the video sounds