### PR TITLE
[appinio_swiper] Dispose the controller to avoid memory leaks

### DIFF
--- a/packages/appinio_swiper/lib/appinio_swiper.dart
+++ b/packages/appinio_swiper/lib/appinio_swiper.dart
@@ -255,6 +255,7 @@ class _AppinioSwiperState extends State<AppinioSwiper>
   void dispose() {
     super.dispose();
     _animationController.dispose();
+    widget.controller?.dispose();
   }
 
   @override


### PR DESCRIPTION
## Description

The controller wasn't being disposed of, which can cause memory leaks, so dispose of it when disposing of the widget