### PR TITLE
[appinio_swiper] Remove const in example code

### DIFF
--- a/packages/appinio_swiper/README.md
+++ b/packages/appinio_swiper/README.md
@@ -99,7 +99,7 @@ class Example extends StatelessWidget {
           cardsBuilder: (BuildContext context,int index){
               return Container(
                           alignment: Alignment.center,
-                          child: const Text(index.toString()),
+                          child: Text(index.toString()),
                           color: CupertinoColors.activeBlue,
                           );
           },


### PR DESCRIPTION
`Text(index.toString())` cannot be const.