### PR TITLE
[appinio_swiper] feat: allowBackgroundCardsDifference

### DIFF
--- a/packages/appinio_swiper/lib/appinio_swiper.dart
+++ b/packages/appinio_swiper/lib/appinio_swiper.dart
@@ -68,6 +68,9 @@ class AppinioSwiper extends StatefulWidget {
   /// direction in which the card gets swiped when triggered by controller, default set to right
   final AppinioSwiperDirection direction;
 
+  ///background cards difference
+  final bool allowBackgroundCardsDifference;
+
   const AppinioSwiper({
     Key? key,
     required this.cardsBuilder,
@@ -89,6 +92,7 @@ class AppinioSwiper extends StatefulWidget {
     this.onEnd,
     this.unswipe,
     this.direction = AppinioSwiperDirection.right,
+    this.allowBackgroundCardsDifference = false,
   })  : assert(maxAngle >= 0 && maxAngle <= 360),
         assert(threshold >= 1 && threshold <= 100),
         assert(direction != AppinioSwiperDirection.none),
@@ -327,8 +331,10 @@ class _AppinioSwiperState extends State<AppinioSwiper>
     int j = 1;
     double difference = _difference;
     double scale = _scale;
-    while ((i < widget.cardsCount || widget.loop) && j <= widget.backgroundCardsCount) {
-      backgroundCards.add(_backgroundItem(constraints, i, difference , scale));
+    while ((i < widget.cardsCount || widget.loop) &&
+        j <= widget.backgroundCardsCount) {
+      backgroundCards.add(_backgroundItem(constraints, i,
+          widget.allowBackgroundCardsDifference ? difference : 0, scale));
       difference += _backgroundCardsDifference;
       scale -= _backgroundCardsScaleDifference;
       i++;
@@ -337,7 +343,8 @@ class _AppinioSwiperState extends State<AppinioSwiper>
     return backgroundCards.reversed.toList();
   }
 
-  Widget _backgroundItem(BoxConstraints constraints, int index, double difference, double scale) {
+  Widget _backgroundItem(
+      BoxConstraints constraints, int index, double difference, double scale) {
     return Positioned(
       top: difference,
       left: 0,


### PR DESCRIPTION
enable or disable the overlay effect

prevents the footer of the background card from showing over the edges of the card on the front, for cases where you don't want to show the elevation

![Screenshot_1689726147](https://github.com/appinioGmbH/flutter_packages/assets/22581144/f5cb05e1-7711-4583-8cbb-228c656a5dd0)


The result is as follows:

[mejora.webm](https://github.com/appinioGmbH/flutter_packages/assets/22581144/19d8d9e1-0cc9-4d73-9717-8c556c0682e5)


This is the way I found to do it, since the optimal thing would be to parameterize the value:

`double_difference = 40;`

but the `40 `is hardcoded in many places of the rendering

