### PR TITLE
[Swiper] Move onEnd down

### DIFF
--- a/packages/appinio_swiper/lib/appinio_swiper.dart
+++ b/packages/appinio_swiper/lib/appinio_swiper.dart
@@ -237,13 +237,6 @@ class _AppinioSwiperState extends State<AppinioSwiper>
       CancelSwipe() => _position._baseIndex,
       DrivenActivity() => _position._baseIndex,
     });
-    if (targetIndex >= widget.cardCount && newActivity is Swipe) {
-      // We reached the end, do not run the activity.
-      if (targetIndex > widget.cardCount && !widget.loop) {
-        return;
-      }
-      widget.onEnd?.call();
-    }
     _swipeActivity = newActivity;
     if (newActivity is Swipe) {
       _activityHistory.add(newActivity);
@@ -275,6 +268,15 @@ class _AppinioSwiperState extends State<AppinioSwiper>
     });
     await _previousActivityFuture;
     widget.onSwipeEnd?.call(previousIndex, targetIndex, newActivity);
+
+    if (targetIndex >= widget.cardCount && newActivity is Swipe) {
+      // We reached the end, do not run the activity.
+      if (targetIndex > widget.cardCount && !widget.loop) {
+        return;
+      }
+      widget.onEnd?.call();
+    }
+
     setState(() {});
   }
 


### PR DESCRIPTION
A bug exists where performing actions that dispose the AppinioSwiper (due to a route change) in the `onEnd` callback result in a rebuild while the AppinioSwiper itself is already being disposed. Moving the `onEnd` callback down solves this issue.