### PR TITLE
fix(social_share): android facebook sdk initialize method is deprecated and causing invalid facebook app id

### DIFF
--- a/packages/appinio_social_share/android/src/main/java/com/appinio/socialshare/appinio_social_share/utils/SocialShareUtil.java
+++ b/packages/appinio_social_share/android/src/main/java/com/appinio/socialshare/appinio_social_share/utils/SocialShareUtil.java
@@ -184,7 +184,9 @@ public class SocialShareUtil {
 
 
     public void shareToFacebook(String imagePath, String text, Activity activity, MethodChannel.Result result) {
-        FacebookSdk.sdkInitialize(activity.getApplicationContext());
+        final String appsID = getFacebookAppId(activity.getApplicationContext());
+        FacebookSdk.setApplicationId(appsID);
+
         callbackManager = callbackManager == null ? CallbackManager.Factory.create() : callbackManager;
         ShareDialog shareDialog = new ShareDialog(activity);
         shareDialog.registerCallback(callbackManager, new FacebookCallback<Sharer.Result>() {
@@ -213,6 +215,7 @@ public class SocialShareUtil {
                 .setShareHashtag(new ShareHashtag.Builder().setHashtag(text).build())
                 .setPhotos(sharePhotos)
                 .build();
+
         if (ShareDialog.canShow(SharePhotoContent.class)) {
             shareDialog.show(content);
         }
@@ -373,6 +376,7 @@ public class SocialShareUtil {
             }
         } catch (PackageManager.NameNotFoundException e) {
             // Handle the exception if needed
+            return appId;
         }
 
         return appId;


### PR DESCRIPTION
### Background

currently in `packages/appinio_social_share/android/src/main/java/com/appinio/socialshare/appinio_social_share/utils/SocialShareUtil.java` method `shareToFacebook` contain logic to trigger `FacebookSdk.initialize()` that automatically setup the facebook app id, _**but**_ currently i encountered issue in android 11+ everytime `shareToFacebook` is triggered, it always return error _**valid facebook app id must be supplied**_ and i already make sure i already setup my `androidManifest.xml` correctly.

### Root Cause

i've been tinkering for a while and found the root cause is in `FacebookSdk.initialize()` method, that method is already deprecated and failed to automatically set the facebook app id for android 11+


### Solution

we need to set the facebook app id manually in order to fix this, so i omit `FacebookSdk.initialize()`  and add `FacebookSdk.setApplicationId();` to imperatively set facebook app id.
