### PR TITLE
Fixed background card index problem

### DIFF
--- a/packages/appinio_swiper/lib/appinio_swiper.dart
+++ b/packages/appinio_swiper/lib/appinio_swiper.dart
@@ -363,7 +363,7 @@ class _AppinioSwiperState extends State<AppinioSwiper>
             position: _position,
             indices: List.generate(
               effectiveBackgroundCardCount,
-              (index) => (foregroundIndex + 1) % widget.cardCount,
+              (index) => (foregroundIndex + index + 1) % widget.cardCount,
             ),
             builder: widget.cardBuilder,
             scaleIncrement: _effectiveScaleIncrement,


### PR DESCRIPTION
Addresses issue  #215 and older issue #190 (same issue).

Old code used same index value for every background card.  Tested fix in my app.