### PR TITLE
widget_zoom - add option to close fullscreen image when WidgetZoom is disposed

### DIFF
--- a/packages/widget_zoom/CHANGELOG.md
+++ b/packages/widget_zoom/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.0.4] - 2024.03.07
+
+- Added `closeFullScreenImageOnDispose` option to `WidgetZoom`.
+
 ## [0.0.3] - 2023.12.21
 
 - Updated readme.

--- a/packages/widget_zoom/README.md
+++ b/packages/widget_zoom/README.md
@@ -42,7 +42,7 @@ Just wrap your image widget that should be zoomable with the `WidgetZoom` and pa
 It doesn't need more setup than this:
 
 ```dart
- ZoomWidget(
+ WidgetZoom(
     heroAnimationTag: 'tag',
     zoomWidget: Image.network(
         'https://i.picsum.photos/id/1076/1000/800.jpg?hmac=Dlz3UOB04NkIUuAcoyNPNP_uRbjWK9FSoHfy4i04yWI',
@@ -61,5 +61,7 @@ It doesn't need more setup than this:
 | minScaleFullscreen           | 1                  | The smallest allowed scale when zooming the widget in fullscreen             |  false   |
 | maxScaleFullscreen           | 4                  | The highest allowed scale when zooming the widget in fullscreen              |  false   |
 | fullScreenDoubleTapZoomScale | maxScaleFullscreen | The zoom scale when double tapping the zoomable widget in fullscreen         |  false   |
+| closeFullScreenImageOnDispose | false | Controls whether the full screen image will be closed once the widget is disposed. | false |
+
 
 <hr/>Made with ❤ by Flutter team at <a href="https://appinio.com">Appinio GmbH</a>

--- a/packages/widget_zoom/example/pubspec.lock
+++ b/packages/widget_zoom/example/pubspec.lock
@@ -190,7 +190,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.3"
+    version: "0.0.4"
 sdks:
   dart: ">=3.2.0-194.0.dev <4.0.0"
   flutter: ">=1.17.0"

--- a/packages/widget_zoom/pubspec.yaml
+++ b/packages/widget_zoom/pubspec.yaml
@@ -1,6 +1,6 @@
 name: widget_zoom
 description: A widget to zoom another widget either directly in an overlay or in fullscreen.
-version: 0.0.3
+version: 0.0.4
 homepage: https://github.com/appinioGmbH/flutter_packages
 repository: https://github.com/appinioGmbH/flutter_packages/tree/main/packages/widget_zoom
 


### PR DESCRIPTION
Context:

At the moment if you click on the image it will be opened in full screen, by pushing a new route to the navigator stack. If the `WidgetZoom` widget is disposed the full screen image remains visible.

Added a property so we can configure this behaviour and made it available to pop the route if the widget is disposed.