### PR TITLE
appino_swiper - fix card move

### DIFF
--- a/packages/appinio_swiper/lib/appinio_swiper.dart
+++ b/packages/appinio_swiper/lib/appinio_swiper.dart
@@ -427,19 +427,36 @@ class _AppinioSwiperState extends State<AppinioSwiper>
                 setState(() {
                   final swipeOption = widget.swipeOptions;
 
+                  final canMoveDown =
+                      (swipeOption.down || _position.offset.dy < 0) &&
+                          tapInfo.delta.dy > 0;
+                  final canMoveUp =
+                      (swipeOption.up || _position.offset.dy > 0) &&
+                          tapInfo.delta.dy < 0;
+                  final canMoveLeft =
+                      (swipeOption.left || _position.offset.dx > 0) &&
+                          tapInfo.delta.dx < 0;
+                  final canMoveRight =
+                      (swipeOption.right || _position.offset.dx < 0) &&
+                          tapInfo.delta.dx > 0;
+
                   final Offset tapDelta = tapInfo.delta;
+
                   double dx = 0;
                   double dy = 0;
-                  if (swipeOption.up && tapDelta.dy < 0) {
+
+                  if (canMoveUp) {
                     dy = tapDelta.dy;
-                  } else if (swipeOption.down && tapInfo.delta.dy > 0) {
+                  } else if (canMoveDown) {
                     dy = tapDelta.dy;
                   }
-                  if (swipeOption.left && tapDelta.dx < 0) {
+
+                  if (canMoveLeft) {
                     dx = tapDelta.dx;
-                  } else if (swipeOption.right && tapInfo.delta.dx > 0) {
+                  } else if (canMoveRight) {
                     dx = tapDelta.dx;
                   }
+
                   _position.offset += Offset(dx, dy);
                 });
                 _onSwiping();


### PR DESCRIPTION
If we forbid a card to be moved in a certain direction, for example down here:
`
swipeOptions: const SwipeOptions.only(
                          left: true,
                          right: true,
                          up: true,
                        )
`
If we move the card in the opposite direction, we can no longer return it to its place. Like in the video.

https://github.com/appinioGmbH/flutter_packages/assets/25247802/71a61eac-217d-45da-a824-d7e187c11748

So we need to give the ability to return the card to its original place. Now it works like this.


https://github.com/appinioGmbH/flutter_packages/assets/25247802/a2094820-cea6-432e-a95f-c38050af3a11

