### PR TITLE
Remove url in the iOS Twitter share feature

### DIFF
--- a/packages/appinio_social_share/ios/Classes/ShareUtil.swift
+++ b/packages/appinio_social_share/ios/Classes/ShareUtil.swift
@@ -474,9 +474,7 @@ public class ShareUtil{
             return
         }
         
-        
         let composeCtl = SLComposeViewController(forServiceType: SLServiceTypeTwitter)
-        composeCtl?.add(URL(string: title!))
         if(!(images==nil)){
             for image in images! {
                 composeCtl?.add(UIImage.init(contentsOfFile: image))


### PR DESCRIPTION
For iOS Twitter sharing, the text string is used twice, once as initial text, and another time as url. If the text is not a URL, then the tweet has 2 lines of text, first line as plain text, and second line as URL encoded string. I think it makes more sense to remove setting the text as URL in this method, and URL content could be supported separately in a different method. 