### PR TITLE
feat: sharing a link on Facebook

### DIFF
--- a/packages/appinio_social_share/android/src/main/java/com/appinio/socialshare/appinio_social_share/AppinioSocialSharePlugin.java
+++ b/packages/appinio_social_share/android/src/main/java/com/appinio/socialshare/appinio_social_share/AppinioSocialSharePlugin.java
@@ -30,6 +30,7 @@ public class AppinioSocialSharePlugin implements FlutterPlugin, MethodCallHandle
     private final String INSTAGRAM_FEED_FILES = "instagram_post_files";
     private final String INSTAGRAM_STORIES = "instagram_stories";
     private final String FACEBOOK = "facebook";
+    private final String FACEBOOK_LINK = "facebook_link";
     private final String MESSENGER = "messenger";
     private final String FACEBOOK_STORIES = "facebook_stories";
     private final String WHATSAPP_ANDROID = "whatsapp_android";
@@ -106,6 +107,10 @@ public class AppinioSocialSharePlugin implements FlutterPlugin, MethodCallHandle
             case FACEBOOK:
                 if (activity == null) return SocialShareUtil.UNKNOWN_ERROR;
                 socialShareUtil.shareToFacebook(imagePaths, message, activity, result);
+                return null;
+            case FACEBOOK_LINK:
+                if (activity == null) return SocialShareUtil.UNKNOWN_ERROR;
+                socialShareUtil.shareLinkToFacebook(message, activity, result);
                 return null;
             case WHATSAPP_ANDROID:
                 return socialShareUtil.shareToWhatsApp(imagePath, message, activeContext);

--- a/packages/appinio_social_share/android/src/main/java/com/appinio/socialshare/appinio_social_share/utils/SocialShareUtil.java
+++ b/packages/appinio_social_share/android/src/main/java/com/appinio/socialshare/appinio_social_share/utils/SocialShareUtil.java
@@ -23,6 +23,7 @@ import com.facebook.FacebookException;
 import com.facebook.FacebookSdk;
 import com.facebook.share.Sharer;
 import com.facebook.share.model.ShareHashtag;
+import com.facebook.share.model.ShareLinkContent;
 import com.facebook.share.model.SharePhoto;
 import com.facebook.share.model.SharePhotoContent;
 import com.facebook.share.widget.ShareDialog;
@@ -271,6 +272,39 @@ public class SocialShareUtil {
                 .setPhotos(sharePhotos)
                 .build();
         if (ShareDialog.canShow(SharePhotoContent.class)) {
+            shareDialog.show(content);
+        }
+    }
+
+    public void shareLinkToFacebook(String link, Activity activity, MethodChannel.Result result) {
+        FacebookSdk.fullyInitialize();
+        FacebookSdk.setApplicationId(getFacebookAppId(activity));
+        callbackManager = callbackManager == null ? CallbackManager.Factory.create() : callbackManager;
+        ShareDialog shareDialog = new ShareDialog(activity);
+        shareDialog.registerCallback(callbackManager, new FacebookCallback<Sharer.Result>() {
+            @Override
+            public void onSuccess(Sharer.Result result1) {
+                System.out.println("---------------onSuccess");
+                result.success(SUCCESS);
+            }
+
+            @Override
+            public void onCancel() {
+                result.success(ERROR_CANCELLED);
+            }
+
+            @Override
+            public void onError(FacebookException error) {
+                System.out.println("---------------onError");
+                result.success(error.getLocalizedMessage());
+            }
+        });
+    
+        ShareLinkContent content = new ShareLinkContent.Builder()
+                .setContentUrl(Uri.parse(link))
+                .build();
+
+        if (ShareDialog.canShow(ShareLinkContent.class)) {
             shareDialog.show(content);
         }
     }

--- a/packages/appinio_social_share/ios/Classes/ShareUtil.swift
+++ b/packages/appinio_social_share/ios/Classes/ShareUtil.swift
@@ -317,6 +317,25 @@ public class ShareUtil{
         result(self.SUCCESS)
         
     }
+
+    func shareLinkToFacebook(args : [String: Any?],result: @escaping FlutterResult, delegate: SharingDelegate) {
+        let message = args[self.argMessage] as? String
+
+        guard let url = URL(string: message ?? "") else {
+            result(ERROR)
+            return
+        }
+
+        let content = ShareLinkContent()
+        content.contentURL = url
+
+        let dialog = ShareDialog(
+            viewController: UIApplication.shared.windows.first!.rootViewController,
+            content: content,
+            delegate: delegate
+        )
+        dialog.show()
+    }
     
     
     func shareToTelegram(args : [String: Any?],result: @escaping FlutterResult) {

--- a/packages/appinio_social_share/ios/Classes/SwiftAppinioSocialSharePlugin.swift
+++ b/packages/appinio_social_share/ios/Classes/SwiftAppinioSocialSharePlugin.swift
@@ -12,6 +12,7 @@ public class SwiftAppinioSocialSharePlugin: NSObject, FlutterPlugin, SharingDele
     private let INSTAGRAM_STORIES:String = "instagram_stories";
     private let INSTAGRAM_POST:String = "instagram_post";
     private let FACEBOOK:String = "facebook";
+    private let FACEBOOK_LINK:String = "facebook_link";
     private let FACEBOOK_STORIES = "facebook_stories";
     private let MESSENGER = "messenger";
     private let WHATSAPP:String = "whatsapp";
@@ -55,6 +56,9 @@ public class SwiftAppinioSocialSharePlugin: NSObject, FlutterPlugin, SharingDele
           break
       case FACEBOOK_STORIES:
           shareUtil.shareToFacebookStory(args:args!,result:result)
+          break
+    case FACEBOOK_LINK:
+          shareUtil.shareLinkToFacebook(args:args!,result:result,delegate: self)
           break
       case WHATSAPP_IMG_IOS:
           shareUtil.shareImageToWhatsApp(args:args!, result:result,delegate: self)

--- a/packages/appinio_social_share/lib/appinio_social_share_method_channel.dart
+++ b/packages/appinio_social_share/lib/appinio_social_share_method_channel.dart
@@ -12,6 +12,7 @@ class MethodChannelAppinioSocialShare extends AppinioSocialSharePlatform {
   final String instagramFeedFiles = "instagram_post_files";
   final String instagramStories = "instagram_stories";
   final String facebook = "facebook";
+  final String facebookLink = "facebook_link";
   final String messenger = "messenger";
   final String facebookStories = "facebook_stories";
   final String whatsapp = "whatsapp";
@@ -286,5 +287,11 @@ class MethodChannelAppinioSocialShare extends AppinioSocialSharePlatform {
     return ((await methodChannel.invokeMethod<String>(
             facebook, {"imagePaths": filePaths, "message": hashtag})) ??
         "");
+  }
+
+  @override
+  Future<String> shareLinkToFacebook(String link) async {
+    return ((await methodChannel.invokeMethod<String>(
+            facebookLink, {"message": link})) ?? "");
   }
 }

--- a/packages/appinio_social_share/lib/appinio_social_share_platform_interface.dart
+++ b/packages/appinio_social_share/lib/appinio_social_share_platform_interface.dart
@@ -77,6 +77,10 @@ abstract class AppinioSocialSharePlatform extends PlatformInterface {
     throw UnimplementedError('platformVersion() has not been implemented.');
   }
 
+  Future<String> shareLinkToFacebook(String link) {
+    throw UnimplementedError('platformVersion() has not been implemented.');
+  }
+
   Future<String> shareToInstagramStory(String appId,
       {String? stickerImage,
       String? backgroundImage,

--- a/packages/appinio_social_share/lib/platforms/android.dart
+++ b/packages/appinio_social_share/lib/platforms/android.dart
@@ -53,9 +53,17 @@ class Android {
     return AppinioSocialSharePlatform.instance.copyToClipBoard(message);
   }
 
+  /// Sharing photos with hashtag.
+  /// It does not allow sharing just a hastag without photos.
   Future<String> shareToFacebook(String hashtag, List<String> filePaths) {
     return AppinioSocialSharePlatform.instance
         .shareToFacebook(hashtag, filePaths);
+  }
+
+  /// Sharing link. 
+  /// It must be in format of URL. Plain text won't work.
+  Future<String> shareLinkToFacebook(String link) {
+    return AppinioSocialSharePlatform.instance.shareLinkToFacebook(link);
   }
 
   Future<String> shareToInstagramStory(String appId,

--- a/packages/appinio_social_share/lib/platforms/ios.dart
+++ b/packages/appinio_social_share/lib/platforms/ios.dart
@@ -40,9 +40,17 @@ class IOS {
     return AppinioSocialSharePlatform.instance.copyToClipBoard(message);
   }
 
+  /// Sharing photos with hashtag.
+  /// It does not allow sharing just a hastag without photos.
   Future<String> shareToFacebook(String hashtag, List<String> filePaths) {
     return AppinioSocialSharePlatform.instance
         .shareToFacebook(hashtag, filePaths);
+  }
+
+  /// Sharing link. 
+  /// It must be in format of URL. Plain text won't work.
+  Future<String> shareLinkToFacebook(String link) {
+    return AppinioSocialSharePlatform.instance.shareLinkToFacebook(link);
   }
 
   Future<String> shareToInstagramStory(String appId,


### PR DESCRIPTION
Hi! 👋 
I added `shareLinkToFacebook` method in order to allow posting link without attaching images.
Solves the following issue: https://github.com/appinioGmbH/flutter_packages/issues/302

Please let me know if any changes need to be made. I am not familiar with Swift and Java.