### PR TITLE
Fix: Exit Full Screen

### DIFF
--- a/packages/appinio_video_player/lib/src/custom_video_player_controller.dart
+++ b/packages/appinio_video_player/lib/src/custom_video_player_controller.dart
@@ -94,7 +94,9 @@ class CustomVideoPlayerController {
     _setOrientationForVideo();
     SystemChrome.setEnabledSystemUIMode(
         customVideoPlayerSettings.systemUIModeInsideFullscreen);
-    await Navigator.of(context).push(route);
+    if(context.mounted){
+      await Navigator.of(context).push(route);
+    }
   }
 
   Future<void> _exitFullscreen() async {

--- a/packages/appinio_video_player/lib/src/custom_video_player_controller.dart
+++ b/packages/appinio_video_player/lib/src/custom_video_player_controller.dart
@@ -105,7 +105,9 @@ class CustomVideoPlayerController {
     await SystemChrome.setPreferredOrientations(customVideoPlayerSettings
         .deviceOrientationsAfterFullscreen); // reset device orientation values
     _isFullscreen = false;
-    Navigator.of(context).pop();
+    if(context.mounted){
+      Navigator.of(context).pop();
+    }
   }
 
   void _setOrientationForVideo() {

--- a/packages/appinio_video_player/lib/src/custom_video_player_controller.dart
+++ b/packages/appinio_video_player/lib/src/custom_video_player_controller.dart
@@ -25,6 +25,7 @@ extension ProtectedCustomVideoPlayerController on CustomVideoPlayerController {
 
 class CustomVideoPlayerController {
   double _lastVolume = 0.5;
+
   Duration get getPosition => videoPlayerController.value.position;
   final BuildContext context;
   CachedVideoPlayerController videoPlayerController;
@@ -105,7 +106,7 @@ class CustomVideoPlayerController {
     await SystemChrome.setPreferredOrientations(customVideoPlayerSettings
         .deviceOrientationsAfterFullscreen); // reset device orientation values
     _isFullscreen = false;
-    if(context.mounted){
+    if (context.mounted) {
       Navigator.of(context).pop();
     }
   }


### PR DESCRIPTION
Fix for this error:

`CustomVideoPlayerController._exitFullscreen
io.flutter.plugins.firebase.crashlytics.FlutterError - Null check operator used on a null value`