### PR TITLE
widget_zoom - add option to customize close icon

### DIFF
--- a/packages/widget_zoom/CHANGELOG.md
+++ b/packages/widget_zoom/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.0.5] - 2024.12.16
+
+- Added `closeIcon` option to `WidgetZoom`.
+
 ## [0.0.4] - 2024.03.07
 
 - Added `closeFullScreenImageOnDispose` option to `WidgetZoom`.

--- a/packages/widget_zoom/README.md
+++ b/packages/widget_zoom/README.md
@@ -52,16 +52,17 @@ It doesn't need more setup than this:
 
 ## Constructor
 
-| Parameter                    | Default            | Description                                                                  | Required |
-| ---------------------------- | :----------------- | :--------------------------------------------------------------------------- | :------: |
-| zoomWidget                   | -                  | The widget that should be zoomable                                           |   true   |
-| heroAnimationTag             | -                  | An object used for the Hero animation when navigating to and from fullscreen |   true   |
-| minScaleEmbeddedView         | 1                  | The smallest allowed scale when zooming the widget not in fullscreen         |  false   |
-| maxScaleEmbeddedView         | 4                  | The highest allowed scale when zooming the widget not in fullscreen          |  false   |
-| minScaleFullscreen           | 1                  | The smallest allowed scale when zooming the widget in fullscreen             |  false   |
-| maxScaleFullscreen           | 4                  | The highest allowed scale when zooming the widget in fullscreen              |  false   |
-| fullScreenDoubleTapZoomScale | maxScaleFullscreen | The zoom scale when double tapping the zoomable widget in fullscreen         |  false   |
-| closeFullScreenImageOnDispose | false | Controls whether the full screen image will be closed once the widget is disposed. | false |
+| Parameter                     | Default              | Description                                                                        | Required |
+| ----------------------------  | :------------------- | :--------------------------------------------------------------------------------- | :------: |
+| zoomWidget                    | -                    | The widget that should be zoomable                                                 |   true   |
+| heroAnimationTag              | -                    | An object used for the Hero animation when navigating to and from fullscreen       |   true   |
+| minScaleEmbeddedView          | 1                    | The smallest allowed scale when zooming the widget not in fullscreen               |  false   |
+| maxScaleEmbeddedView          | 4                    | The highest allowed scale when zooming the widget not in fullscreen                |  false   |
+| minScaleFullscreen            | 1                    | The smallest allowed scale when zooming the widget in fullscreen                   |  false   |
+| maxScaleFullscreen            | 4                    | The highest allowed scale when zooming the widget in fullscreen                    |  false   |
+| fullScreenDoubleTapZoomScale  | maxScaleFullscreen   | The zoom scale when double tapping the zoomable widget in fullscreen               |  false   |
+| closeFullScreenImageOnDispose | false                | Controls whether the full screen image will be closed once the widget is disposed. |  false   |
+| closeIcon                     | CupertinoIcons.xmark | Widget displayed at the top right corner of the full screen image that closes it.  |  false   |
 
 
 <hr/>Made with ❤ by Flutter team at <a href="https://appinio.com">Appinio GmbH</a>

--- a/packages/widget_zoom/lib/src/widget_zoom.dart
+++ b/packages/widget_zoom/lib/src/widget_zoom.dart
@@ -26,6 +26,10 @@ class WidgetZoom extends StatefulWidget {
   /// Controls whether the full screen image will be closed once the widget is disposed.
   final bool closeFullScreenImageOnDispose;
 
+  /// Widget displayed at the top right corner of the full screen image. Closes the overlay when tapped.
+  /// If not specified, [CupertinoIcons.xmark] will be displayed in white color.
+  final Widget? closeIcon;
+
   const WidgetZoom({
     Key? key,
     this.minScaleEmbeddedView = 1,
@@ -36,6 +40,7 @@ class WidgetZoom extends StatefulWidget {
     this.closeFullScreenImageOnDispose = false,
     required this.heroAnimationTag,
     required this.zoomWidget,
+    this.closeIcon,
   }) : super(key: key);
 
   @override
@@ -195,6 +200,7 @@ class _WidgetZoomState extends State<WidgetZoom>
             maxScale: widget.maxScaleFullscreen,
             heroAnimationTag: widget.heroAnimationTag,
             fullScreenDoubleTapZoomScale: widget.fullScreenDoubleTapZoomScale,
+            closeIcon: widget.closeIcon,
           ),
         ),
         transitionDuration: const Duration(milliseconds: 300),

--- a/packages/widget_zoom/lib/src/widget_zoom_full_screen.dart
+++ b/packages/widget_zoom/lib/src/widget_zoom_full_screen.dart
@@ -7,6 +7,7 @@ class WidgetZoomFullscreen extends StatefulWidget {
   final double maxScale;
   final Object heroAnimationTag;
   final double? fullScreenDoubleTapZoomScale;
+  final Widget? closeIcon;
   const WidgetZoomFullscreen({
     Key? key,
     required this.zoomWidget,
@@ -14,6 +15,7 @@ class WidgetZoomFullscreen extends StatefulWidget {
     required this.maxScale,
     required this.heroAnimationTag,
     this.fullScreenDoubleTapZoomScale,
+    this.closeIcon,
   }) : super(key: key);
 
   @override
@@ -54,6 +56,12 @@ class _ImageZoomFullscreenState extends State<WidgetZoomFullscreen>
 
   @override
   Widget build(BuildContext context) {
+    final closeIcon = widget.closeIcon ??
+        const Icon(
+          CupertinoIcons.xmark,
+          color: Colors.white,
+          size: 30,
+        );
     return Stack(
       children: [
         Positioned.fill(
@@ -101,16 +109,12 @@ class _ImageZoomFullscreenState extends State<WidgetZoomFullscreen>
               child: AnimatedOpacity(
                 duration: _opacityDuration,
                 opacity: _opacity,
-                child: const Padding(
-                  padding: EdgeInsets.symmetric(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
                     horizontal: 10,
                     vertical: 5,
                   ),
-                  child: Icon(
-                    CupertinoIcons.xmark,
-                    color: Colors.white,
-                    size: 30,
-                  ),
+                  child: closeIcon,
                 ),
               ),
             ),

--- a/packages/widget_zoom/pubspec.yaml
+++ b/packages/widget_zoom/pubspec.yaml
@@ -1,6 +1,6 @@
 name: widget_zoom
 description: A widget to zoom another widget either directly in an overlay or in fullscreen.
-version: 0.0.4
+version: 0.0.5
 homepage: https://github.com/appinioGmbH/flutter_packages
 repository: https://github.com/appinioGmbH/flutter_packages/tree/main/packages/widget_zoom
 


### PR DESCRIPTION
Context: 

Add the ability to customize the close icon of the fill screen widget. By default it uses  a white`CupertinoIcons.xmark`.

<img width="1436" alt="Screenshot 2024-12-16 at 08 00 38" src="https://github.com/user-attachments/assets/76d6e436-9158-4bb7-bde6-ecf33dbfe8a6" />
