### PR TITLE
feat: add optional linkText and linkUrl to shareToInstagramStory()

### DIFF
--- a/packages/appinio_social_share/android/src/main/java/com/appinio/socialshare/appinio_social_share/AppinioSocialSharePlugin.java
+++ b/packages/appinio_social_share/android/src/main/java/com/appinio/socialshare/appinio_social_share/AppinioSocialSharePlugin.java
@@ -86,6 +86,8 @@ public class AppinioSocialSharePlugin implements FlutterPlugin, MethodCallHandle
         String backgroundImage = call.argument("backgroundImage");
         String backgroundTopColor = call.argument("backgroundTopColor");
         String backgroundBottomColor = call.argument("backgroundBottomColor");
+        String linkText = call.argument("linkText");
+        String linkUrl = call.argument("linkUrl");
         switch (call.method) {
             case INSTALLED_APPS:
                 Map<String, Boolean> response = socialShareUtil.getInstalledApps(activeContext);
@@ -98,7 +100,7 @@ public class AppinioSocialSharePlugin implements FlutterPlugin, MethodCallHandle
             case INSTAGRAM_FEED_FILES:
                 return socialShareUtil.shareToInstagramFeedFiles(imagePaths, activeContext,message);
             case INSTAGRAM_STORIES:
-                return socialShareUtil.shareToInstagramStory(appId, stickerImage, backgroundImage, backgroundTopColor, backgroundBottomColor, attributionURL, activeContext);
+                return socialShareUtil.shareToInstagramStory(appId, stickerImage, backgroundImage, backgroundTopColor, backgroundBottomColor, attributionURL, linkText, linkUrl, activeContext);
             case FACEBOOK_STORIES:
                 return socialShareUtil.shareToFaceBookStory(appId, stickerImage, backgroundImage, backgroundTopColor, backgroundBottomColor, attributionURL, activeContext);
             case MESSENGER:

--- a/packages/appinio_social_share/android/src/main/java/com/appinio/socialshare/appinio_social_share/utils/SocialShareUtil.java
+++ b/packages/appinio_social_share/android/src/main/java/com/appinio/socialshare/appinio_social_share/utils/SocialShareUtil.java
@@ -205,7 +205,7 @@ public class SocialShareUtil {
     }
 
 
-    public String shareToInstagramStory(String appId, String stickerImage, String backgroundImage, String backgroundTopColor, String backgroundBottomColor, String attributionURL, Context activity) {
+    public String shareToInstagramStory(String appId, String stickerImage, String backgroundImage, String backgroundTopColor, String backgroundBottomColor, String attributionURL, String linkText, String linkUrl, Context activity) {
 
         try {
 
@@ -229,6 +229,8 @@ public class SocialShareUtil {
             shareIntent.putExtra("content_url", attributionURL);
             shareIntent.putExtra("top_background_color", backgroundTopColor);
             shareIntent.putExtra("bottom_background_color", backgroundBottomColor);
+            shareIntent.putExtra("link_text", linkText);
+            shareIntent.putExtra("link_url", linkUrl);
             activity.startActivity(shareIntent);
             return SUCCESS;
         } catch (Exception e) {

--- a/packages/appinio_social_share/ios/Classes/ShareUtil.swift
+++ b/packages/appinio_social_share/ios/Classes/ShareUtil.swift
@@ -26,6 +26,8 @@ public class ShareUtil{
     let argBackgroundBottomColor: String  = "backgroundBottomColor";
     let argImages: String  = "images";
     let argVideoFile: String  = "videoFile";
+    let argLinkText: String = "linkText";
+    let argLinkUrl: String = "linkUrl";
 
 
     
@@ -499,7 +501,9 @@ public class ShareUtil{
             let backgroundTopColor = args[self.argBackgroundTopColor] as? String
             let backgroundBottomColor =  args[self.argBackgroundBottomColor] as? String
             let attributionURL =  args[self.argAttributionURL] as? String
-
+            let linkText =  args[self.argLinkText] as? String
+            let linkUrl =  args[self.argLinkUrl] as? String
+            
             
             guard let instagramURL = URL(string: "instagram-stories://share?source_application=\(appId!)") else {
                 result(ERROR_APP_NOT_AVAILABLE)
@@ -529,6 +533,8 @@ public class ShareUtil{
                         "com.instagram.sharedSticker.backgroundImage": backgroundImage ?? "",
                         "com.instagram.sharedSticker.backgroundTopColor": backgroundTopColor ?? "",
                         "com.instagram.sharedSticker.backgroundBottomColor": backgroundBottomColor ?? "",
+                        "com.instagram.sharedSticker.linkText": linkText ?? "",
+                        "com.instagram.sharedSticker.linkURL": linkUrl ?? "",
                     ]
                 ]
                 let pasteboardOptions = [

--- a/packages/appinio_social_share/lib/appinio_social_share_method_channel.dart
+++ b/packages/appinio_social_share/lib/appinio_social_share_method_channel.dart
@@ -246,7 +246,9 @@ class MethodChannelAppinioSocialShare extends AppinioSocialSharePlatform {
       String? backgroundVideo,
       String? backgroundTopColor,
       String? backgroundBottomColor,
-      String? attributionURL}) async {
+      String? attributionURL,
+      String? linkText,
+      String? linkUrl}) async {
     return ((await methodChannel.invokeMethod<String>(instagramStories, {
           "stickerImage": stickerImage,
           "backgroundImage":
@@ -255,7 +257,9 @@ class MethodChannelAppinioSocialShare extends AppinioSocialSharePlatform {
           "backgroundTopColor": backgroundTopColor,
           "backgroundBottomColor": backgroundBottomColor,
           "attributionURL": attributionURL,
-          "appId": appId
+          "appId": appId,
+          "linkText": linkText,
+          "linkUrl": linkUrl
         })) ??
         "");
   }

--- a/packages/appinio_social_share/lib/appinio_social_share_platform_interface.dart
+++ b/packages/appinio_social_share/lib/appinio_social_share_platform_interface.dart
@@ -83,7 +83,9 @@ abstract class AppinioSocialSharePlatform extends PlatformInterface {
       String? backgroundVideo,
       String? backgroundTopColor,
       String? backgroundBottomColor,
-      String? attributionURL}) {
+      String? attributionURL,
+      String? linkText,
+      String? linkUrl}) {
     throw UnimplementedError('platformVersion() has not been implemented.');
   }
 

--- a/packages/appinio_social_share/lib/platforms/android.dart
+++ b/packages/appinio_social_share/lib/platforms/android.dart
@@ -64,14 +64,18 @@ class Android {
       String? backgroundVideo,
       String? backgroundTopColor,
       String? backgroundBottomColor,
-      String? attributionURL}) {
+      String? attributionURL,
+      String? linkText,
+      String? linkUrl}) {
     return AppinioSocialSharePlatform.instance.shareToInstagramStory(appId,
         stickerImage: stickerImage,
         backgroundImage: backgroundImage,
         backgroundVideo: backgroundVideo,
         backgroundTopColor: backgroundTopColor,
         backgroundBottomColor: backgroundBottomColor,
-        attributionURL: attributionURL);
+        attributionURL: attributionURL,
+        linkText: linkText,
+        linkUrl: linkUrl);
   }
 
   Future<String> shareToFacebookStory(String appId,

--- a/packages/appinio_social_share/lib/platforms/ios.dart
+++ b/packages/appinio_social_share/lib/platforms/ios.dart
@@ -51,14 +51,18 @@ class IOS {
       String? backgroundVideo,
       String? backgroundTopColor,
       String? backgroundBottomColor,
-      String? attributionURL}) {
+      String? attributionURL,
+      String? linkText,
+      String? linkUrl}) {
     return AppinioSocialSharePlatform.instance.shareToInstagramStory(appId,
         stickerImage: stickerImage,
         backgroundImage: backgroundImage,
         backgroundVideo: backgroundVideo,
         backgroundTopColor: backgroundTopColor,
         backgroundBottomColor: backgroundBottomColor,
-        attributionURL: attributionURL);
+        attributionURL: attributionURL,
+        linkText: linkText,
+        linkUrl: linkUrl);
   }
 
   Future<String> shareToFacebookStory(String appId,


### PR DESCRIPTION
This PR adds support for optional `linkText` and `linkUrl` parameters when sharing to Instagram stories.

With these parameters Instagram renders a sticker in the middle of the story with the text and URL provided. I wish I could link to the official documentation but unfortunately I have not been able to find it yet. I'm only following how this was implemented in the [React Native Share repository](https://github.com/react-native-share/react-native-share/pull/1600). 

I've tested it on iOS but it could do with some testing on Android too.

Hope it helps.

PS: the reason I ended up looking at `linkText` and `linkUrl` is because `attributionUrl` does not seem to have any effect at all.